### PR TITLE
Auto check for dependencies with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,22 @@
+version: 2
+updates:
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "15:30"
+    assignees:
+      - "octocat"
+    labels:
+      - "composer"
+      - "dependencies"
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "15:30"
+    assignees:
+      - "octocat"
+    labels:
+      - "yarn"
+      - "dependencies"


### PR DESCRIPTION
Adds daily GitHub action check to look for updates in `composer` & `yarn`
If updated dependency is found it will auto generate PR. Might be helpful so one does not need to update these manually every so often