### PR TITLE
Update Logout method in SessionDevice

### DIFF
--- a/client/components/session/SessionDevice.vue
+++ b/client/components/session/SessionDevice.vue
@@ -139,7 +139,7 @@ function confirm (session: api.Session) {
 }
 
 async function revoke (session: api.Session) {
-  if (session.current) return this.$auth.logout('local')
+  if (session.current) return $api.logout()
   $toast.show((await $api.delete(`/session/${session.token}`)).data)
   emit('refresh')
 }


### PR DESCRIPTION
The current `this.$auth` is undefined and has no context, using the `$api.logout()` instead